### PR TITLE
Bugfix for "bindingFiles property is not working" #5

### DIFF
--- a/src/main/kotlin/com/github/bjornvester/xjc/XjcTask.kt
+++ b/src/main/kotlin/com/github/bjornvester/xjc/XjcTask.kt
@@ -27,7 +27,7 @@ open class XjcTask @Inject constructor(private val workerExecutor: WorkerExecuto
     @Optional
     @get:InputFiles
     @get:PathSensitive(PathSensitivity.RELATIVE)
-    val xsdFiles = getXjcExtension().xsdFiles
+    var xsdFiles = getXjcExtension().xsdFiles
 
     @get:Classpath
     val xjcConfiguration: NamedDomainObjectProvider<Configuration> = project.configurations
@@ -48,7 +48,7 @@ open class XjcTask @Inject constructor(private val workerExecutor: WorkerExecuto
     @Optional
     @get:InputFiles
     @get:PathSensitive(PathSensitivity.RELATIVE)
-    val bindingFiles = getXjcExtension().bindingFiles
+    var bindingFiles = getXjcExtension().bindingFiles
 
     @get:Input
     val options: ListProperty<String> = project.objects.listProperty(String::class.java).convention(getXjcExtension().options)
@@ -79,6 +79,9 @@ open class XjcTask @Inject constructor(private val workerExecutor: WorkerExecuto
         project.delete(tmpBindFiles)
         project.mkdir(outputJavaDir)
         project.mkdir(outputResourcesDir)
+
+        xsdFiles = getXjcExtension().xsdFiles
+        bindingFiles = getXjcExtension().bindingFiles
 
         validateOptions()
 


### PR DESCRIPTION
Hi, 
I'm also affected by the bug #5 that the bindingFiles property doesn't work. This is a small (and i think ugly) Bugfix, but it allows me to work with this plugin. I think there is a better solution, but I'm neither a Kotlin programmer nor I've much knowledge abouter Gradle plugin programming.
But perhaps you could create a small Bufgix Release for the plugin with this patch, so we don't have to compile and upload it outself and other users can use your plugin.

Greetings