### PR TITLE
Bump versions, remove workaround in XjcWorker

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,7 @@ pluginBundle {
         "xjcPlugin" {
             description = "Changes:\n" +
                     "- Support for third-party plugins\n" +
-                    "- Renamed the 'xjcBind' configuration to 'xjcBindings'\n"
+                    "- Renamed the 'xjcBind' configuration to 'xjcBindings'\n" +
                     "- Support for marking the generated code with the @Generated annotation"
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,11 +1,11 @@
 plugins {
-    kotlin("jvm") version "1.3.50"
+    kotlin("jvm") version "1.3.72"
     id("java-gradle-plugin")
-    id("com.gradle.plugin-publish") version "0.10.1"
+    id("com.gradle.plugin-publish") version "0.12.0"
 }
 
 group = "com.github.bjornvester"
-version = "1.3"
+version = "1.4"
 
 allprojects {
     repositories {
@@ -15,7 +15,7 @@ allprojects {
 
 dependencies {
     implementation(kotlin("stdlib-jdk8"))
-    compileOnly("org.glassfish.jaxb:jaxb-xjc:2.3.2")
+    compileOnly("org.glassfish.jaxb:jaxb-xjc:2.3.3")
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class).all {
@@ -26,7 +26,7 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class).all {
 
 tasks.withType<Wrapper> {
     distributionType = Wrapper.DistributionType.ALL
-    gradleVersion = "5.6.2"
+    gradleVersion = "6.5"
 }
 
 gradlePlugin {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/com/github/bjornvester/xjc/XjcExtension.kt
+++ b/src/main/kotlin/com/github/bjornvester/xjc/XjcExtension.kt
@@ -12,7 +12,7 @@ open class XjcExtension @Inject constructor(project: Project) {
     var xsdFiles: FileCollection = xsdDir.asFileTree.matching { it.include("**/*.xsd") }
     val outputJavaDir: DirectoryProperty = project.objects.directoryProperty().convention(project.layout.buildDirectory.dir("generated/sources/xjc/java"))
     val outputResourcesDir: DirectoryProperty = project.objects.directoryProperty().convention(project.layout.buildDirectory.dir("generated/sources/xjc/resources"))
-    val xjcVersion: Property<String> = project.objects.property(String::class.java).convention("2.3.2")
+    val xjcVersion: Property<String> = project.objects.property(String::class.java).convention("2.3.3")
     val defaultPackage: Property<String> = project.objects.property(String::class.java)
     val generateEpisode: Property<Boolean> = project.objects.property(Boolean::class.java).convention(false)
     var bindingFiles: FileCollection = project.objects.fileCollection()

--- a/src/main/kotlin/com/github/bjornvester/xjc/XjcWorker.kt
+++ b/src/main/kotlin/com/github/bjornvester/xjc/XjcWorker.kt
@@ -13,21 +13,6 @@ abstract class XjcWorker : WorkAction<XjcWorkerParams> {
     private val logger: Logger = LoggerFactory.getLogger(XjcWorker::class.java)
 
     override fun execute() {
-        try {
-            doWork()
-        } finally {
-            /*
-                There is a file leak in XJC (in class PluginImpl) when generating episodes.
-                The leaking resource gets closed in a finalize method, so attempt to do that by nudging the VM to garbage collect it.
-                No guarantees of cause.
-                A PR to fix the leak has been created here: https://github.com/eclipse-ee4j/jaxb-ri/pull/1339.
-                At the time of this writing, it has not been merged in yet (and even if/when it does, it will probably take a while for a new release to come out).
-            */
-            System.gc()
-        }
-    }
-
-    private fun doWork() {
         val options = Options()
         options.disableXmlSecurity = true // Avoids SAXNotRecognizedExceptions in certain places (though not everywhere) - see the note in XjcTask for additional information on this
         configureGeneratedEpisodeFile(options)


### PR DESCRIPTION
Updated the jaxb-xjc to version 2.3.3. According to this [commit message](https://github.com/eclipse-ee4j/jaxb-ri/commit/39add9d139ee99106c3c6ec2f7f795fec8f7c814) it should improve compatibility with Java 11+. For example JPMS module descriptors are added. It also contains [the merged PR](https://github.com/eclipse-ee4j/jaxb-ri/pull/1339) of @bjornvester which fixes the file leak issue. So I also removed the workaround in `com.github.bjornvester.xjc.XjcWorker`. 

Note that in JAXB RI 2.3.3 the class `com.sun.xml.bind.Util` is renamed to `com.sun.xml.bind.Utils` in [this commit](https://github.com/eclipse-ee4j/jaxb-ri/commit/39add9d139ee99106c3c6ec2f7f795fec8f7c814#diff-af9edd449bd449cab7b78388b0f04310R18). This can be a breaking change in some cases.

I'm writing my specific issue here so people can (hopefully) find it via search engines so they won't have to spend hours debugging 😄 
In my case I generated a fresh project with https://start.spring.io/. 
After adding this `xjc-gradle-plugin` my build broke with a vague error: `ERROR: Unable to load class 'com.sun.xml.bind.Util'`.
After some digging I figured that Spring's dependency management enforces the latest JAXB RI 2.3.3, which causes weird classpath issues. In this case the class `com.github.bjornvester.xjc.XjcWorker` makes use of `com.sun.tools.xjc.Options`, which in turn contains the following line: 
`private static final Logger logger = com.sun.xml.bind.Util.getClassLogger();`.
This results in a `ClassNotFoundException` being thrown because the`xjc-gradle-plugin` uses `com.sun.tools.xjc.Options` from jaxb-xjc 2.3.2 (containing `Util`) and Spring enforced jaxb-runtime 2.3.3 (containing `Utils`). So double-check the exact versions on your classpath.